### PR TITLE
path which contains non-ascii character

### DIFF
--- a/src/path.rs
+++ b/src/path.rs
@@ -38,7 +38,7 @@ pub fn canonicalize(path: &str) -> String {
                     if is_absolute {
                         buf.push('/');
                     }
-                } else if &buf[buf.len() - 1..] != "/" {
+                } else if !&buf.ends_with('/') {
                     buf.push('/');
                 }
                 buf.push_str(part);
@@ -93,5 +93,6 @@ mod tests {
         assert_eq!(canonicalize("/bleh/bar/../../foo"), "/foo");
         assert_eq!(canonicalize("/bleh/bar/../../foo/.."), "/");
         assert_eq!(canonicalize("/bleh/bar/../../foo/../meh"), "/meh");
+        assert_eq!(canonicalize("/@test_7_tmpæ/_parent_foo/"), "/@test_7_tmpæ/_parent_foo");
     }
 }


### PR DESCRIPTION

```
[221.642987 0:8 linux_syscall_api::syscall:57] [syscall] id = 34,return 0
[221.645294 0:8 linux_syscall_api::syscall:30] [syscall] id = MKDIRAT, args = [18446744073709551516, 7337296, 511, 7337296, 0, 0], entry
[221.646389 0:8 axfs::root:233] path: /@test_7_tmpæ/_parent_foo/
[221.647076 0:8 axruntime::lang_items:5] panicked at /root/.cargo/git/checkouts/axfs_vfs-8da3527c962285a9/cd00e10/src/path.rs:41:31:
byte index 13 is not a char boundary; it is inside 'æ' (bytes 12..14) of `/@test_7_tmpæ`
[221.649016 0:8 axtask::api:230] dump task: Task(8, "python3.11"), stack range: 0xffff000047bc08d0: 0xffff000047c008d0
[221.650041 0:8 axbacktrace:43] Call trace: 
[221.650368 0:8 axbacktrace::aarch64:74] pc: 0xFFFF0000400EF704  fp=0xFFFF000047BFEE88
[221.650694 0:8 axbacktrace::aarch64:75] 0xFFFF0000400EF704 
[221.651630 0:8 axbacktrace::aarch64:74] pc: 0xFFFF0000400EF59C  fp=0xFFFF000047BFEF68
[221.651707 0:8 axbacktrace::aarch64:75] 0xFFFF0000400EF59C 
[221.651764 0:8 axbacktrace::aarch64:74] pc: 0xFFFF0000400A9FC8  fp=0xFFFF000047BFEF78
[221.651836 0:8 axbacktrace::aarch64:75] 0xFFFF0000400A9FC8 
[221.651970 0:8 axhal::platform::aarch64_common::psci:96] Shutting down...
```
paniced while canonicalizing the path which contained non-ascii character